### PR TITLE
fix: Support multibyte characters for file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API client library for Kintone REST APIs on Java.
     Add dependency declaration in `build.gradle` of your project.
     ```
     dependencies {
-        implementation 'com.kintone:kintone-java-client:1.0.1'
+        implementation 'com.kintone:kintone-java-client:1.0.2'
     }
     ```
 - For projects using Maven  
@@ -17,7 +17,7 @@ API client library for Kintone REST APIs on Java.
     <dependency>
         <groupId>com.kintone</groupId>
         <artifactId>kintone-java-client</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </dependency>
   ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'com.diffplug.gradle.spotless' version '3.25.0'
 }
 
-version = '1.0.1'
+version = '1.0.2'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ client.close();
 Add dependency declaration in `build.gradle` of your project.
 ```groovy
 dependencies {
-     implementation 'com.kintone:kintone-java-client:1.0.1'
+     implementation 'com.kintone:kintone-java-client:1.0.2'
 }
 ```
 
@@ -39,7 +39,7 @@ Add dependency declaration in `pom.xml` of your project.
 <dependency>
     <groupId>com.kintone</groupId>
     <artifactId>kintone-java-client</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 </dependency>
 ```
 

--- a/src/main/java/com/kintone/client/InternalClientImpl.java
+++ b/src/main/java/com/kintone/client/InternalClientImpl.java
@@ -35,6 +35,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.HttpMultipartMode;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -213,7 +214,9 @@ class InternalClientImpl extends InternalClient {
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
         builder.setCharset(StandardCharsets.UTF_8);
         builder.setBoundary(boundary);
+        builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
         builder.setContentType(ContentType.MULTIPART_FORM_DATA);
+
         builder.addPart(
                 "file", new InputStreamBody(content, ContentType.create(contentType), filename));
 


### PR DESCRIPTION
When uploading a file name containing multi-byte characters, it was garbled. 