### PR TITLE
fix: update the response of the Get Space API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API client library for Kintone REST APIs on Java.
     Add dependency declaration in `build.gradle` of your project.
     ```
     dependencies {
-        implementation 'com.kintone:kintone-java-client:1.2.0'
+        implementation 'com.kintone:kintone-java-client:1.2.1'
     }
     ```
 - For projects using Maven  
@@ -17,7 +17,7 @@ API client library for Kintone REST APIs on Java.
     <dependency>
         <groupId>com.kintone</groupId>
         <artifactId>kintone-java-client</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
     </dependency>
   ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'com.github.hierynomus.license' version '0.15.0'
 }
 
-version = '1.2.0'
+version = '1.2.1'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ client.close();
 Add dependency declaration in `build.gradle` of your project.
 ```groovy
 dependencies {
-     implementation 'com.kintone:kintone-java-client:1.2.0'
+     implementation 'com.kintone:kintone-java-client:1.2.1'
 }
 ```
 
@@ -39,7 +39,7 @@ Add dependency declaration in `pom.xml` of your project.
 <dependency>
     <groupId>com.kintone</groupId>
     <artifactId>kintone-java-client</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
 </dependency>
 ```
 

--- a/src/main/java/com/kintone/client/api/space/GetSpaceResponseBody.java
+++ b/src/main/java/com/kintone/client/api/space/GetSpaceResponseBody.java
@@ -72,4 +72,39 @@ public class GetSpaceResponseBody implements KintoneResponseBody {
      * @return true if users cannot join/leave the Space or follow/unfollow threads.
      */
     private final boolean fixedMember;
+
+    /**
+     * Whether the "Announcement" widget in the Space Portal page is shown.
+     *
+     * @return true if the "Announcement" widget is shown.
+     */
+    private final boolean showAnnouncement;
+
+    /**
+     * Whether the "Apps" widget in the Space Portal page is shown.
+     *
+     * @return true if the "Apps" widget is shown.
+     */
+    private final boolean showAppList;
+
+    /**
+     * Whether the "People" widget in the Space Portal page is shown.
+     *
+     * @return true if the "People" widget is shown.
+     */
+    private final boolean showMemberList;
+
+    /**
+     * Whether the "Threads" widget in the Space Portal page is shown.
+     *
+     * @return true if the "Threads" widget is shown.
+     */
+    private final boolean showThreadList;
+
+    /**
+     * Whether the "Related Apps & Spaces" widget in the Space Portal page is shown.
+     *
+     * @return true if the "Related Apps & Spaces" widget is shown.
+     */
+    private final boolean showRelatedLinkList;
 }

--- a/src/test/java/com/kintone/client/SpaceClientTest.java
+++ b/src/test/java/com/kintone/client/SpaceClientTest.java
@@ -162,7 +162,12 @@ public class SpaceClientTest {
                         10,
                         false,
                         false,
-                        false);
+                        false,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true);
         mockClient.setResponseBody(resp);
 
         assertThat(sut.getSpace(10L)).isEqualTo(resp);
@@ -175,7 +180,8 @@ public class SpaceClientTest {
         GetSpaceRequest req = new GetSpaceRequest();
         GetSpaceResponseBody resp =
                 new GetSpaceResponseBody(
-                        1, "", 1, false, null, null, null, "", "", "", null, 1, false, false, false);
+                        1, "", 1, false, null, null, null, "", "", "", null, 1, false, false, false, true, true,
+                        true, true, true);
         mockClient.setResponseBody(resp);
 
         assertThat(sut.getSpace(req)).isEqualTo(resp);


### PR DESCRIPTION
add 5 parameters below which represent the display status of the Space widgets:
- `showAnnouncement`: The "Announcement" widget
- `showAppList`: The "Apps" widget
- `showMemberList`: The "People" widget
- `showThreadList`: The "Threads" widget
- `showRelatedLinkList`: The "Related Apps & Spaces" widget
