### PR TITLE
Change type for Calc Fields from BigDecimal to String

### DIFF
--- a/src/main/java/com/kintone/client/RecordDeserializer.java
+++ b/src/main/java/com/kintone/client/RecordDeserializer.java
@@ -90,8 +90,7 @@ class RecordDeserializer extends StdDeserializer<Record> {
         switch (fieldType) {
             case CALC:
                 {
-                    BigDecimal value = convertValue(node, BigDecimal::new);
-                    return new CalcFieldValue(value);
+                    return new CalcFieldValue(node.textValue());
                 }
             case CATEGORY:
                 {

--- a/src/main/java/com/kintone/client/model/record/CalcFieldValue.java
+++ b/src/main/java/com/kintone/client/model/record/CalcFieldValue.java
@@ -8,7 +8,7 @@ import lombok.Value;
 public class CalcFieldValue implements FieldValue {
 
     /** The value of the Calculated field. */
-    private final BigDecimal value;
+    private final String value;
 
     /** {@inheritDoc} */
     @Override

--- a/src/main/java/com/kintone/client/model/record/Record.java
+++ b/src/main/java/com/kintone/client/model/record/Record.java
@@ -343,7 +343,7 @@ public class Record {
      * @param fieldCode the field code
      * @return the value of the field
      */
-    public BigDecimal getCalcFieldValue(String fieldCode) {
+    public String getCalcFieldValue(String fieldCode) {
         CalcFieldValue value = (CalcFieldValue) fields.get(fieldCode);
         return value == null ? null : value.getValue();
     }

--- a/src/main/java/com/kintone/client/model/record/TableRow.java
+++ b/src/main/java/com/kintone/client/model/record/TableRow.java
@@ -231,7 +231,7 @@ public class TableRow {
      * @param fieldCode the field code
      * @return the value of the field
      */
-    public BigDecimal getCalcFieldValue(String fieldCode) {
+    public String getCalcFieldValue(String fieldCode) {
         CalcFieldValue value = (CalcFieldValue) fields.get(fieldCode);
         return value == null ? null : value.getValue();
     }

--- a/src/test/java/com/kintone/client/RecordDeserializerTest.java
+++ b/src/test/java/com/kintone/client/RecordDeserializerTest.java
@@ -109,8 +109,9 @@ public class RecordDeserializerTest {
                         .setFileKey("key");
         ZonedDateTime dateTime = ZonedDateTime.of(2020, 1, 2, 3, 4, 0, 0, ZoneOffset.UTC);
 
-        assertThat(record.getFieldCodes(true)).hasSize(18);
-        assertThat(record.getFieldValue("calc")).isEqualTo(new CalcFieldValue(new BigDecimal(100)));
+        assertThat(record.getFieldCodes(true)).hasSize(19);
+        assertThat(record.getFieldValue("calc")).isEqualTo(new CalcFieldValue("100"));
+        assertThat(record.getFieldValue("date_calc")).isEqualTo(new CalcFieldValue("2020-01-01"));
         assertThat(record.getFieldValue("check_box"))
                 .isEqualTo(new CheckBoxFieldValue("option 1", "option 2"));
         assertThat(record.getFieldValue("date"))

--- a/src/test/java/com/kintone/client/RecordSerializerTest.java
+++ b/src/test/java/com/kintone/client/RecordSerializerTest.java
@@ -69,7 +69,7 @@ public class RecordSerializerTest {
 
     @Test
     public void serialize_CALC() throws IOException {
-        Record record = new Record().putField("calc", new CalcFieldValue(new BigDecimal(100)));
+        Record record = new Record().putField("calc", new CalcFieldValue("100"));
         String json = mapper.writeValueAsString(record);
         assertThat(json).isEqualTo("{}");
     }

--- a/src/test/resources/com/kintone/client/RecordDeserializerTest_deserialize_fields.json
+++ b/src/test/resources/com/kintone/client/RecordDeserializerTest_deserialize_fields.json
@@ -4,6 +4,10 @@
       "type": "CALC",
       "value": "100"
     },
+    "date_calc": {
+      "type": "CALC",
+      "value": "2020-01-01"
+    },
     "check_box": {
       "type": "CHECK_BOX",
       "value": [


### PR DESCRIPTION
As documented at https://developer.cybozu.io/hc/ja/articles/202166330-%E3%83%95%E3%82%A3%E3%83%BC%E3%83%AB%E3%83%89%E5%BD%A2%E5%BC%8F, a Calc field can contain a string representation of a Date, DateTime, or Time in addition to a number. Therefore, we cannot assume that the data will be parsable as a BigDecimal, and the simplest/cleanest fix is just to keep the value as a string and let the consumer of the API handle appropriately.