### PR TITLE
feat: Add methods to get the raw string value of Calculated fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API client library for Kintone REST APIs on Java.
     Add dependency declaration in `build.gradle` of your project.
     ```
     dependencies {
-        implementation 'com.kintone:kintone-java-client:1.3.1'
+        implementation 'com.kintone:kintone-java-client:1.4.0'
     }
     ```
 - For projects using Maven  
@@ -17,7 +17,7 @@ API client library for Kintone REST APIs on Java.
     <dependency>
         <groupId>com.kintone</groupId>
         <artifactId>kintone-java-client</artifactId>
-        <version>1.3.1</version>
+        <version>1.4.0</version>
     </dependency>
   ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'com.github.hierynomus.license' version '0.15.0'
 }
 
-version = '1.3.1'
+version = '1.4.0'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ client.close();
 Add dependency declaration in `build.gradle` of your project.
 ```groovy
 dependencies {
-     implementation 'com.kintone:kintone-java-client:1.3.1'
+     implementation 'com.kintone:kintone-java-client:1.4.0'
 }
 ```
 
@@ -39,7 +39,7 @@ Add dependency declaration in `pom.xml` of your project.
 <dependency>
     <groupId>com.kintone</groupId>
     <artifactId>kintone-java-client</artifactId>
-    <version>1.3.1</version>
+    <version>1.4.0</version>
 </dependency>
 ```
 

--- a/src/main/java/com/kintone/client/RecordDeserializer.java
+++ b/src/main/java/com/kintone/client/RecordDeserializer.java
@@ -89,9 +89,7 @@ class RecordDeserializer extends StdDeserializer<Record> {
     private FieldValue deserialize(FieldType fieldType, JsonNode node) {
         switch (fieldType) {
             case CALC:
-                {
-                    return new CalcFieldValue(node.textValue());
-                }
+                return new CalcFieldValue(node.textValue());
             case CATEGORY:
                 {
                     List<String> value = convertValues(node, JsonNode::textValue);

--- a/src/main/java/com/kintone/client/model/record/CalcFieldValue.java
+++ b/src/main/java/com/kintone/client/model/record/CalcFieldValue.java
@@ -1,17 +1,56 @@
 package com.kintone.client.model.record;
 
-import lombok.Value;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.FieldDefaults;
 
 /** A value object for a Calculated field. */
-@Value
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@ToString
+@EqualsAndHashCode(doNotUseGetters = true)
 public class CalcFieldValue implements FieldValue {
 
     /** The value of the Calculated field. */
     private final String value;
 
+    public CalcFieldValue(String rawValue) {
+        this.value = rawValue;
+    }
+
+    public CalcFieldValue(BigDecimal value) {
+        if (value != null) {
+            this.value = value.toPlainString();
+        } else {
+            this.value = null;
+        }
+    }
+
     /** {@inheritDoc} */
     @Override
     public FieldType getType() {
         return FieldType.CALC;
+    }
+
+    /**
+     * Returns the value of field.
+     *
+     * @return the value of field.
+     */
+    public BigDecimal getValue() {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return new BigDecimal(value);
+    }
+
+    /**
+     * Returns the raw value of field.
+     *
+     * @return the raw value of field.
+     */
+    public String getRawValue() {
+        return value;
     }
 }

--- a/src/main/java/com/kintone/client/model/record/Record.java
+++ b/src/main/java/com/kintone/client/model/record/Record.java
@@ -343,9 +343,20 @@ public class Record {
      * @param fieldCode the field code
      * @return the value of the field
      */
-    public String getCalcFieldValue(String fieldCode) {
+    public BigDecimal getCalcFieldValue(String fieldCode) {
         CalcFieldValue value = (CalcFieldValue) fields.get(fieldCode);
         return value == null ? null : value.getValue();
+    }
+
+    /**
+     * Returns the raw value of a Calculated field.
+     *
+     * @param fieldCode the field code
+     * @return the raw value of the field
+     */
+    public String getCalcFieldRawValue(String fieldCode) {
+        CalcFieldValue value = (CalcFieldValue) fields.get(fieldCode);
+        return value == null ? null : value.getRawValue();
     }
 
     /**

--- a/src/main/java/com/kintone/client/model/record/TableRow.java
+++ b/src/main/java/com/kintone/client/model/record/TableRow.java
@@ -231,9 +231,20 @@ public class TableRow {
      * @param fieldCode the field code
      * @return the value of the field
      */
-    public String getCalcFieldValue(String fieldCode) {
+    public BigDecimal getCalcFieldValue(String fieldCode) {
         CalcFieldValue value = (CalcFieldValue) fields.get(fieldCode);
         return value == null ? null : value.getValue();
+    }
+
+    /**
+     * Returns the raw value of a Calculated field.
+     *
+     * @param fieldCode the field code
+     * @return the raw value of the field
+     */
+    public String getCalcFieldRawValue(String fieldCode) {
+        CalcFieldValue value = (CalcFieldValue) fields.get(fieldCode);
+        return value == null ? null : value.getRawValue();
     }
 
     /**

--- a/src/test/java/com/kintone/client/RecordDeserializerTest.java
+++ b/src/test/java/com/kintone/client/RecordDeserializerTest.java
@@ -109,9 +109,12 @@ public class RecordDeserializerTest {
                         .setFileKey("key");
         ZonedDateTime dateTime = ZonedDateTime.of(2020, 1, 2, 3, 4, 0, 0, ZoneOffset.UTC);
 
-        assertThat(record.getFieldCodes(true)).hasSize(19);
-        assertThat(record.getFieldValue("calc")).isEqualTo(new CalcFieldValue("100"));
-        assertThat(record.getFieldValue("date_calc")).isEqualTo(new CalcFieldValue("2020-01-01"));
+        assertThat(record.getFieldCodes(true)).hasSize(21);
+        assertThat(record.getFieldValue("calc")).isEqualTo(new CalcFieldValue(new BigDecimal(100)));
+        assertThat(record.getFieldValue("calc_date")).isEqualTo(new CalcFieldValue("2022-01-01"));
+        assertThat(record.getFieldValue("calc_datetime"))
+                .isEqualTo(new CalcFieldValue("2022-01-01T00:00:00Z"));
+        assertThat(record.getFieldValue("calc_time")).isEqualTo(new CalcFieldValue("12:34"));
         assertThat(record.getFieldValue("check_box"))
                 .isEqualTo(new CheckBoxFieldValue("option 1", "option 2"));
         assertThat(record.getFieldValue("date"))

--- a/src/test/java/com/kintone/client/RecordSerializerTest.java
+++ b/src/test/java/com/kintone/client/RecordSerializerTest.java
@@ -69,7 +69,11 @@ public class RecordSerializerTest {
 
     @Test
     public void serialize_CALC() throws IOException {
-        Record record = new Record().putField("calc", new CalcFieldValue("100"));
+        Record record =
+                new Record()
+                        .putField("calc", new CalcFieldValue(new BigDecimal(100)))
+                        .putField("calc_date", new CalcFieldValue("2022-01-01"))
+                        .putField("calc_null", new CalcFieldValue((BigDecimal) null));
         String json = mapper.writeValueAsString(record);
         assertThat(json).isEqualTo("{}");
     }

--- a/src/test/resources/com/kintone/client/RecordDeserializerTest_deserialize_fields.json
+++ b/src/test/resources/com/kintone/client/RecordDeserializerTest_deserialize_fields.json
@@ -4,9 +4,17 @@
       "type": "CALC",
       "value": "100"
     },
-    "date_calc": {
+    "calc_date": {
       "type": "CALC",
-      "value": "2020-01-01"
+      "value": "2022-01-01"
+    },
+    "calc_datetime": {
+      "type": "CALC",
+      "value": "2022-01-01T00:00:00Z"
+    },
+    "calc_time": {
+      "type": "CALC",
+      "value": "12:34"
     },
     "check_box": {
       "type": "CHECK_BOX",


### PR DESCRIPTION
- Adds `String CalcFieldValue.getRawValue()`, `String Record.getCalcFieldRawValue(String)` and `String TableRow.getCalcFieldRawValue(String)`.
- Fixes the return value types of `CalcFieldValue.getValue()`, `Record.getCalcFieldValue(String)` and `TableRow.getCalcFieldValue(String)`
  to avoid breaking changes in https://github.com/kintone/kintone-java-client/pull/34.
  These methods return `BigDecimal` as before.