### PR TITLE
docs: replacing devnet URL from old version link to new version link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,4 +14,4 @@ API client library for Kintone APIs on Java.
 
 - To find the specifications of Kintone REST API in English, visits
   [Kintone Developer Program (https://developer.kintone.io/hc/en-us)](https://developer.kintone.io/hc/en-us) 
-- In Japanese, see [Cybozu Developer Network (https://developer.cybozu.io/hc/ja)](https://developer.cybozu.io/hc/ja)
+- In Japanese, see [Cybozu Developer Network (https://cybozu.dev/ja)](https://cybozu.dev/ja)


### PR DESCRIPTION
The new devnet have been released, and devnet URL will be changed.
So, now we need to change to the new one.

| old | new |
| ---| --- |
| https://developer.cybozu.io/ | https://cybozu.dev/ |
