### PR TITLE
ci: add `permissions` to `javadoc` workflow

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -10,6 +10,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
     - uses: actions/checkout@v2
     - name: Cache gradle files


### PR DESCRIPTION
## Why

For security improvement, we want to make the default workflow permission `read-only`.
In this PR, we update the `javadoc` workflow because it requires additional permission.

## What

- add proper permissions to javadoc.yml
  - `peaceiris/actions-gh-pages@v3` action requires`contents: write` permission ([ref](https://github.com/peaceiris/actions-gh-pages#️-first-deployment-with-github_token))

NOTE: stale.yml also requires [additional permission](https://github.com/actions/stale#recommended-permissions), but it's already configured ([ref](https://github.com/kintone/kintone-java-client/blob/ce7f5fdd1fd451d78bfa22a6f55ce1dbd3669109/.github/workflows/stale.yml#L9))