### PR TITLE
Implementing a workaround for an invalid format in the defaultValue.

### DIFF
--- a/src/main/java/com/kintone/client/model/app/field/DateTimeFieldProperty.java
+++ b/src/main/java/com/kintone/client/model/app/field/DateTimeFieldProperty.java
@@ -3,6 +3,8 @@ package com.kintone.client.model.app.field;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.kintone.client.model.record.FieldType;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import lombok.Data;
 
 /**
@@ -12,6 +14,8 @@ import lombok.Data;
 @Data
 @JsonIgnoreProperties(value = "type", allowGetters = true)
 public class DateTimeFieldProperty implements FieldProperty {
+
+    private final DateTimeFormatter DEFAULT_VALUE_FORMATTER = DateTimeFormatter.ISO_ZONED_DATE_TIME;
 
     /** The field code of the field. */
     private String code;
@@ -54,5 +58,24 @@ public class DateTimeFieldProperty implements FieldProperty {
     @Override
     public FieldType getType() {
         return FieldType.DATETIME;
+    }
+
+    // Kintone API returns defaultValue in the format of `yyyy-MM-dd'T'HH:mm`.
+    // This value is lack of compatibility with the ISO-8601 format, so DateTimeParseException occurs like following.
+    // java.time.format.DateTimeParseException: Text '2019-03-27T10:15' could not be parsed: Unable to obtain ZonedDateTime from TemporalAccessor: {},ISO resolved to 2019-03-27T10:15 of type java.time.format.Parsed
+    // This is a workaround until the API returns the expected format.
+    public void setDefaultValue(String defaultValue) {
+        if (defaultValue.isEmpty()) {
+            return;
+        }
+        try {
+            this.defaultValue = ZonedDateTime.parse(defaultValue, DEFAULT_VALUE_FORMATTER);
+        } catch (DateTimeParseException ex) {
+            if (defaultValue.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}")) {
+                this.defaultValue = ZonedDateTime.parse(defaultValue + ":00Z", DEFAULT_VALUE_FORMATTER);
+            } else {
+                throw ex;
+            }
+        }
     }
 }

--- a/src/test/resources/com/kintone/client/FieldPropertyDeserializerTest_deserialize_DATETIME.json
+++ b/src/test/resources/com/kintone/client/FieldPropertyDeserializerTest_deserialize_DATETIME.json
@@ -6,7 +6,7 @@
     "noLabel": false,
     "required": false,
     "unique": false,
-    "defaultValue": "2020-01-01T01:30:00.000Z",
+    "defaultValue": "2020-01-01T01:30",
     "defaultNowValue": false
   }
 }


### PR DESCRIPTION
[ get fields api](https://cybozu.dev/ja/kintone/docs/rest-api/apps/form/get-form-fields/) returns defaultValue in the format of `yyyy-MM-dd'T'HH:mm`. e.g. `2023-12-08T12:34`.
 This value is lack of compatibility with the ISO-8601 format, so DateTimeParseException occurs like following.
```
java.time.format.DateTimeParseException: Text '2019-03-27T10:15' could not be parsed: Unable to obtain ZonedDateTime from TemporalAccessor: {},ISO resolved to 2019-03-27T10:15 of type java.time.format.Parsed
```
This is a workaround until the API returns the expected format.