### PR TITLE
fix!: Change the value type of a Calculated field to String

### DIFF
--- a/src/main/java/com/kintone/client/model/record/CalcFieldValue.java
+++ b/src/main/java/com/kintone/client/model/record/CalcFieldValue.java
@@ -1,6 +1,5 @@
 package com.kintone.client.model.record;
 
-import java.math.BigDecimal;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -15,16 +14,8 @@ public class CalcFieldValue implements FieldValue {
     /** The value of the Calculated field. */
     private final String value;
 
-    public CalcFieldValue(String rawValue) {
-        this.value = rawValue;
-    }
-
-    public CalcFieldValue(BigDecimal value) {
-        if (value != null) {
-            this.value = value.toPlainString();
-        } else {
-            this.value = null;
-        }
+    public CalcFieldValue(String value) {
+        this.value = value;
     }
 
     /** {@inheritDoc} */
@@ -38,19 +29,7 @@ public class CalcFieldValue implements FieldValue {
      *
      * @return the value of field.
      */
-    public BigDecimal getValue() {
-        if (value == null || value.isEmpty()) {
-            return null;
-        }
-        return new BigDecimal(value);
-    }
-
-    /**
-     * Returns the raw value of field.
-     *
-     * @return the raw value of field.
-     */
-    public String getRawValue() {
+    public String getValue() {
         return value;
     }
 }

--- a/src/main/java/com/kintone/client/model/record/Record.java
+++ b/src/main/java/com/kintone/client/model/record/Record.java
@@ -343,20 +343,9 @@ public class Record {
      * @param fieldCode the field code
      * @return the value of the field
      */
-    public BigDecimal getCalcFieldValue(String fieldCode) {
+    public String getCalcFieldValue(String fieldCode) {
         CalcFieldValue value = (CalcFieldValue) fields.get(fieldCode);
         return value == null ? null : value.getValue();
-    }
-
-    /**
-     * Returns the raw value of a Calculated field.
-     *
-     * @param fieldCode the field code
-     * @return the raw value of the field
-     */
-    public String getCalcFieldRawValue(String fieldCode) {
-        CalcFieldValue value = (CalcFieldValue) fields.get(fieldCode);
-        return value == null ? null : value.getRawValue();
     }
 
     /**

--- a/src/main/java/com/kintone/client/model/record/TableRow.java
+++ b/src/main/java/com/kintone/client/model/record/TableRow.java
@@ -231,20 +231,9 @@ public class TableRow {
      * @param fieldCode the field code
      * @return the value of the field
      */
-    public BigDecimal getCalcFieldValue(String fieldCode) {
+    public String getCalcFieldValue(String fieldCode) {
         CalcFieldValue value = (CalcFieldValue) fields.get(fieldCode);
         return value == null ? null : value.getValue();
-    }
-
-    /**
-     * Returns the raw value of a Calculated field.
-     *
-     * @param fieldCode the field code
-     * @return the raw value of the field
-     */
-    public String getCalcFieldRawValue(String fieldCode) {
-        CalcFieldValue value = (CalcFieldValue) fields.get(fieldCode);
-        return value == null ? null : value.getRawValue();
     }
 
     /**

--- a/src/test/java/com/kintone/client/RecordDeserializerTest.java
+++ b/src/test/java/com/kintone/client/RecordDeserializerTest.java
@@ -110,7 +110,7 @@ public class RecordDeserializerTest {
         ZonedDateTime dateTime = ZonedDateTime.of(2020, 1, 2, 3, 4, 0, 0, ZoneOffset.UTC);
 
         assertThat(record.getFieldCodes(true)).hasSize(21);
-        assertThat(record.getFieldValue("calc")).isEqualTo(new CalcFieldValue(new BigDecimal(100)));
+        assertThat(record.getFieldValue("calc")).isEqualTo(new CalcFieldValue("100"));
         assertThat(record.getFieldValue("calc_date")).isEqualTo(new CalcFieldValue("2022-01-01"));
         assertThat(record.getFieldValue("calc_datetime"))
                 .isEqualTo(new CalcFieldValue("2022-01-01T00:00:00Z"));

--- a/src/test/java/com/kintone/client/RecordSerializerTest.java
+++ b/src/test/java/com/kintone/client/RecordSerializerTest.java
@@ -71,9 +71,9 @@ public class RecordSerializerTest {
     public void serialize_CALC() throws IOException {
         Record record =
                 new Record()
-                        .putField("calc", new CalcFieldValue(new BigDecimal(100)))
+                        .putField("calc", new CalcFieldValue("100"))
                         .putField("calc_date", new CalcFieldValue("2022-01-01"))
-                        .putField("calc_null", new CalcFieldValue((BigDecimal) null));
+                        .putField("calc_null", new CalcFieldValue(null));
         String json = mapper.writeValueAsString(record);
         assertThat(json).isEqualTo("{}");
     }


### PR DESCRIPTION
**BREAKING CHANGE**

- Remove `CalcFieldValue#getRawValue()` and `CalcFieldValue(BigDecimal)` to simplify the value type of Calc field
  - `CalcFieldValue#getRawValue()` was introduced to avoid the issue: 
     https://github.com/kintone/kintone-java-client/pull/36
- `CalcFieldValue#getValue()` now returns a String value
